### PR TITLE
feat: optional statusline-hook source for no-live installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ To turn the check off entirely, comment out the `getUpdateInfo()` call near the 
 - **No conversation content.** From the Codex session-log fallback it parses only the `rate_limits` object (numbers), never the messages.
 - **Auditable in one sitting.** The whole widget is a single dependency-free script — grep for `curl`/`fetch` and you've seen every network call it can make.
 
+### Fully local mode (`--statusline-hook`)
+
+If you'd rather the widget never touch the Keychain *and* never call the usage APIs, install with:
+
+```bash
+./install.sh --statusline-hook
+```
+
+This creates `~/.claude/swiftbar/.no-live` (disables both live queries; Codex falls back to session logs) and wires a small hook into Claude Code's `statusLine` (`~/.claude/settings.json`, backed up to `settings.json.ccb-bak`). Claude Code pipes `rate_limits` to the statusline while a session runs — its only network-free outlet for that data — and the hook caches it at `~/.claude/swiftbar/usage-cache.json` for the widget, passing your existing statusline through untouched. Trade-offs: numbers update only while a Claude Code session is running, reflect this Mac's login rather than combining devices, and the Fable battery is not available (the statusline feed carries only the two plan-wide windows).
+
 ---
 
 ## How accurate / in-sync is it?
@@ -200,7 +210,7 @@ Both queries are read-only and cost **no tokens** — you never have to *use* Cl
 | Refresh interval | filename `.2m.` → `.1m.`, `.5m.`, `.30s.`, … |
 | Battery size | **↕ row in the dropdown** — toggles between big (4×6 font, default) and small (3×5 font, ~25% narrower); stored in `~/.claude/swiftbar/.batt-size` |
 | Color thresholds | `heatRemain` / `heatRemainHex` (20 % / 50 %) |
-| Disable live Claude + Codex APIs (Keychain / token access) | `touch ~/.claude/swiftbar/.no-live` (falls back to local cache files) |
+| Disable live Claude + Codex APIs (Keychain / token access) | `touch ~/.claude/swiftbar/.no-live` (falls back to local cache files), or `./install.sh --statusline-hook` for a [fully local Claude source](#fully-local-mode---statusline-hook) |
 | Which Claude limits to show | the `battItems.push(...)` block |
 
 ---

--- a/ccb-limits-cache.js
+++ b/ccb-limits-cache.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env bun
+// Optional statusline hook — a fully local data source for the C batteries.
+//
+// For users who opt out of Keychain access / live usage-API queries via
+// ~/.claude/swiftbar/.no-live. Claude Code pipes session JSON — including
+// `rate_limits` (5h / weekly used_percentage + resets_at) — to the configured
+// statusLine command; that stdin JSON is the only place it exposes rate
+// limits without a network call. This script sits in the statusline chain,
+// caches them to ~/.claude/swiftbar/usage-cache.json (read by the widget as
+// a fallback source), then hands the input through to the user's original
+// statusline command untouched (or prints a minimal model-name line if the
+// user had none).
+//
+// Wiring (done by `install.sh --statusline-hook`):
+//   bun .ccb-limits-cache.js --install
+// rewrites statusLine.command in ~/.claude/settings.json to route through
+// this script, wrapping any pre-existing command as argv[2].
+
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  renameSync,
+  copyFileSync,
+  existsSync,
+} from "node:fs";
+import { homedir } from "node:os";
+
+const HOME = homedir();
+const SETTINGS = `${HOME}/.claude/settings.json`;
+const CACHE_DIR = `${HOME}/.claude/swiftbar`;
+
+// ── install mode: wire ourselves into settings.json ──
+if (process.argv[2] === "--install") {
+  const shq = (x) => `'${String(x).replaceAll("'", `'\\''`)}'`;
+  let s = {};
+  if (existsSync(SETTINGS)) {
+    // If settings.json is corrupt, fail loudly rather than overwrite it.
+    s = JSON.parse(readFileSync(SETTINGS, "utf8"));
+  }
+  const cur = s.statusLine?.command ?? "";
+  if (cur.includes("ccb-limits-cache.js")) {
+    console.log("statusline hook already wired");
+    process.exit(0);
+  }
+  if (existsSync(SETTINGS)) copyFileSync(SETTINGS, `${SETTINGS}.ccb-bak`);
+  const self = process.argv[1];
+  const cmd = cur
+    ? `${shq(process.execPath)} ${shq(self)} ${shq(cur)}`
+    : `${shq(process.execPath)} ${shq(self)}`;
+  s.statusLine = { type: "command", command: cmd };
+  writeFileSync(SETTINGS, JSON.stringify(s, null, 2) + "\n");
+  console.log(
+    cur ? `wrapped existing statusline: ${cur}` : "installed as statusline",
+  );
+  process.exit(0);
+}
+
+// ── statusline mode: cache rate_limits, then pass through ──
+const input = readFileSync(0, "utf8");
+let j = {};
+try {
+  j = JSON.parse(input);
+} catch {}
+
+const rl = j.rate_limits;
+if (rl && (rl.five_hour || rl.seven_day)) {
+  try {
+    // statusline gives epoch seconds; the widget parses ISO strings
+    const iso = (t) =>
+      t == null
+        ? null
+        : typeof t === "number"
+          ? new Date(t * 1000).toISOString()
+          : String(t);
+    const win = (o) =>
+      o
+        ? { utilization: o.used_percentage ?? 0, resets_at: iso(o.resets_at) }
+        : null;
+    mkdirSync(CACHE_DIR, { recursive: true });
+    const out = JSON.stringify({
+      five_hour: win(rl.five_hour),
+      seven_day: win(rl.seven_day),
+    });
+    // write + rename = atomic, so the widget never reads a partial file
+    writeFileSync(`${CACHE_DIR}/usage-cache.json.tmp`, out);
+    renameSync(
+      `${CACHE_DIR}/usage-cache.json.tmp`,
+      `${CACHE_DIR}/usage-cache.json`,
+    );
+  } catch {
+    // a cache failure must never break the user's statusline
+  }
+}
+
+const orig = process.argv[2];
+if (orig) {
+  const p = Bun.spawnSync(["sh", "-c", orig], {
+    stdin: Buffer.from(input),
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  process.exit(p.exitCode ?? 0);
+} else {
+  process.stdout.write(j.model?.display_name ?? "");
+}

--- a/claude-codex-usage.2m.js
+++ b/claude-codex-usage.2m.js
@@ -145,6 +145,12 @@ const TR3 = {
     "zh-Hant": "{0} 前的快取（備援 — 請檢查 Claude Code 登入/網路）",
     es: "caché de hace {0} (respaldo — revisa sesión/red de Claude Code)",
   },
+  "measured {0} ago (local session log)": {
+    ja: "{0}前に測定 (ローカルセッションログ)",
+    "zh-Hans": "{0} 前测量（本地会话日志）",
+    "zh-Hant": "{0} 前測量（本機工作階段日誌）",
+    es: "medido hace {0} (registro de sesión local)",
+  },
   "live query failed — check login/network (local log from {0} ago)": {
     ja: "ライブ取得失敗 — ログイン/ネットワークを確認 ({0}前のローカルログ)",
     "zh-Hans": "实时查询失败 — 请检查登录/网络（{0} 前的本地日志）",
@@ -1262,7 +1268,10 @@ if (hasCodex) {
   out.push(
     codex.live
       ? `${L("라이브 (ChatGPT usage API — 전 디바이스 합산)", "live (ChatGPT usage API — all devices combined)")} | size=11 color=#8b949e`
-      : `⚠ ${tf("라이브 조회 실패 — 로그인·네트워크 확인 ({0} 전 로컬 로그값)", "live query failed — check login/network (local log from {0} ago)", fmtDur(age))} | size=11 color=#d29922`,
+      : existsSync(`${CLAUDE_STATE_DIR}/.no-live`)
+        ? // deliberate opt-out (.no-live): local session logs are the intended source, not an error
+          `${tf("측정 {0} 전 (로컬 세션 로그)", "measured {0} ago (local session log)", fmtDur(age))} | size=11 color=#8b949e`
+        : `⚠ ${tf("라이브 조회 실패 — 로그인·네트워크 확인 ({0} 전 로컬 로그값)", "live query failed — check login/network (local log from {0} ago)", fmtDur(age))} | size=11 color=#d29922`,
   );
   out.push("---");
 }

--- a/claude-codex-usage.2m.js
+++ b/claude-codex-usage.2m.js
@@ -133,6 +133,12 @@ const TR3 = {
     "zh-Hant": "即時（ChatGPT usage API — 所有裝置合計）",
     es: "en vivo (ChatGPT usage API — todos los dispositivos)",
   },
+  "measured {0} ago (statusline feed — local, this Mac)": {
+    ja: "{0}前に測定 (statuslineフィード — ローカル·このMac)",
+    "zh-Hans": "{0} 前测量（statusline 数据源 — 本机）",
+    "zh-Hant": "{0} 前測量（statusline 資料來源 — 本機）",
+    es: "medido hace {0} (fuente statusline — local, este Mac)",
+  },
   "cached {0} ago (fallback — check Claude Code login/network)": {
     ja: "{0}前のキャッシュ (フォールバック — Claude Codeのログイン/ネットワークを確認)",
     "zh-Hans": "{0} 前的缓存（回退 — 请检查 Claude Code 登录/网络）",
@@ -701,6 +707,10 @@ const CLAUDE_USAGE_CACHE = `${CLAUDE_STATE_DIR}/.claude-usage.json`;
 const CODEX_AUTH = `${HOME}/.codex/auth.json`;
 const CODEX_USAGE_CACHE = `${CLAUDE_STATE_DIR}/.codex-usage.json`;
 const LEGACY_USAGE_FILES = [
+  // written by the optional statusline hook (install.sh --statusline-hook)
+  // for .no-live users — same shape as the API response, kept fresh while
+  // a Claude Code session is running
+  `${CLAUDE_STATE_DIR}/usage-cache.json`,
   `${HOME}/.claude/MEMORY/STATE/usage-cache.json`,
   `${HOME}/.claude/PAI/MEMORY/STATE/usage-cache.json`,
 ];
@@ -1169,7 +1179,10 @@ if (hasClaude) {
     out.push(
       cusage.live
         ? `${L("라이브 (Anthropic usage API — 전 디바이스 합산)", "live (Anthropic usage API — all devices combined)")} | size=11 color=#8b949e`
-        : `${tf("측정 {0} 전 (캐시 폴백 — Claude Code 로그인·네트워크 확인)", "cached {0} ago (fallback — check Claude Code login/network)", fmtDur(now - cusage.measuredAt))} | size=11 color=#d29922`,
+        : existsSync(`${CLAUDE_STATE_DIR}/.no-live`)
+          ? // deliberate opt-out (.no-live): the statusline hook is the intended source, not an error
+            `${tf("측정 {0} 전 (statusline 피드 — 로컬·이 Mac)", "measured {0} ago (statusline feed — local, this Mac)", fmtDur(now - cusage.measuredAt))} | size=11 color=#8b949e`
+          : `${tf("측정 {0} 전 (캐시 폴백 — Claude Code 로그인·네트워크 확인)", "cached {0} ago (fallback — check Claude Code login/network)", fmtDur(now - cusage.measuredAt))} | size=11 color=#d29922`,
     );
   }
   if (claude && !claude.error) {

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,13 @@
 set -e
 cd "$(dirname "$0")"
 
+# --statusline-hook (off by default): fully local C-battery source for users who
+# don't want Keychain access or live usage-API calls. See step 5b.
+STATUSLINE_HOOK=0
+for arg in "$@"; do
+  [ "$arg" = "--statusline-hook" ] && STATUSLINE_HOOK=1
+done
+
 echo "🔋 Claude & Codex Usage Battery — Install"
 echo "────────────────────────────────────"
 
@@ -46,6 +53,29 @@ chmod +x "$PLUGIN_DIR/claude-codex-usage.2m.js"
 cp ccb-update.sh "$PLUGIN_DIR/.ccb-update.sh"
 chmod +x "$PLUGIN_DIR/.ccb-update.sh"
 echo "✅ Plugin deployed: $PLUGIN_DIR"
+
+# 5b) Optional statusline-hook source (--statusline-hook, off by default).
+#     Claude Code pipes rate_limits to the statusLine command's stdin — its only
+#     network-free outlet for that data. The hook caches it for the widget, then
+#     runs the user's original statusline unchanged. Creating .no-live disables
+#     all live queries (Codex falls back to session logs).
+if [ "$STATUSLINE_HOOK" = "1" ]; then
+  cp ccb-limits-cache.js "$PLUGIN_DIR/.ccb-limits-cache.js"
+  if [ -d "$HOME/.claude" ]; then
+    if "$BUN" "$PLUGIN_DIR/.ccb-limits-cache.js" --install; then
+      mkdir -p "$HOME/.claude/swiftbar"
+      touch "$HOME/.claude/swiftbar/.no-live"
+      # drop the stale live-response cache so the hook's fresher data wins the fallback chain
+      rm -f "$HOME/.claude/swiftbar/.claude-usage.json"
+      echo "✅ statusline hook wired + live queries disabled (.no-live)"
+      echo "   C batteries update from Claude Code's statusline feed while a session is running"
+    else
+      echo "⚠️  statusline hook wiring failed — check ~/.claude/settings.json (falling back to live queries)"
+    fi
+  else
+    echo "⚠️  --statusline-hook: ~/.claude not found — is Claude Code installed?"
+  fi
+fi
 
 # 6) Point SwiftBar at the folder + launch
 BID=$(defaults read /Applications/SwiftBar.app/Contents/Info CFBundleIdentifier 2>/dev/null || echo "com.ameba.SwiftBar")


### PR DESCRIPTION
## Summary
- Reworked per review: now an opt-in add-on for `.no-live` users, rebased onto current main (v2.6.1).
- `./install.sh --statusline-hook` (off by default) wires a hook into Claude Code's statusLine that caches `rate_limits` to `~/.claude/swiftbar/usage-cache.json` — its only network-free outlet for that data. Original statusline passes through untouched; `settings.json` backed up to `.ccb-bak`. The flag also creates `.no-live` and clears the stale live-response cache so the hook's data wins the fallback chain.
- With `.no-live` set, the dropdown labels the reading as the intended local source (gray, "statusline feed — local, this Mac") instead of the amber login/network warning. Translations included.

## Validation
- Sandboxed HOME: `--install` is idempotent, wraps an existing statusline byte-identically, and with `.no-live` + no ccusage/codex the C batteries render from the hook cache with the new gray label (ko/en checked).
- `bash -n install.sh` passes; default install path untouched.