### PR TITLE
docs: credit Windows contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cd windows
 
 See the [Windows documentation](windows/README.md) for optional start-at-login, privacy controls and uninstall instructions. Windows support is currently experimental; the macOS app remains the primary release.
 
+**Windows contributors:** [@daehyeonxyz](https://github.com/daehyeonxyz) — initial Windows prototype ([#3](https://github.com/dennykim123/claude-codex-battery/pull/3)) · [@johnjheejin](https://github.com/johnjheejin) — production port and stabilization ([#5](https://github.com/dennykim123/claude-codex-battery/pull/5))
+
 ### macOS
 
 ### Option 1 — Native app (no SwiftBar, no bun)


### PR DESCRIPTION
## What changed

- Credited @daehyeonxyz for the initial Windows prototype in PR #3.
- Credited @johnjheejin for the production Windows port and stabilization in PR #5.
- Placed the acknowledgement directly in the Windows section so each contribution is clear in context.

## Why

PR #3 was not merged, so GitHub does not automatically show @daehyeonxyz as a contributor even though the prototype helped establish the Windows direction.

## Validation

- Reviewed the rendered Markdown diff.
- Ran `git diff --check` successfully.
